### PR TITLE
Expose as vendor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+dist: trusty
 
 addons:
   apt:
@@ -23,21 +23,19 @@ matrix:
 
 before_script:
 # Init PHP
-  - if [[ $PHPCS_TEST ]]; then pyrus install pear/PHP_CodeSniffer; fi
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 # Install composer dependencies
+  - export PATH=~/.composer/vendor/bin:$PATH
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/cms:4.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev
   - composer update
 
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
-
-# Bootstrap cms / mysite folder
-  - php cms/tests/bootstrap/mysite.php
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 script:
  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests flush=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,11 @@ before_script:
 
 # Install composer dependencies
   - export PATH=~/.composer/vendor/bin:$PATH
-  - composer install --prefer-dist
-  - composer require --prefer-dist --no-update symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/cms:4.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev
-  - composer update
-
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
+  - composer require --no-update --prefer-dist silverstripe/recipe-cms:1.0.x-dev
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
+  - if [[ $DB == SQLITE ]]; then composer require --no-update silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests flush=1; fi

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "silverstripe/errorpage",
     "description": "ErrorPage component for SilverStripe CMS",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "silverstripe/cms": "^4@dev"
+        "silverstripe/cms": "^4@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "~5.7"
@@ -29,8 +30,7 @@
         "branch-alias": {
             "1.x-dev": "1.0.x-dev",
             "dev-master": "2.x-dev"
-        },
-        "installer-name": "silverstripe-errorpage"
+        }
     },
     "scripts": {
         "lint": "phpcs -s src/ tests/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 Standard module phpunit configuration.
 Requires PHPUnit ^5.7
 -->
-<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 	<testsuite name="Default">
 		<directory>tests</directory>
     </testsuite>


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395
Blocked by https://github.com/silverstripe/silverstripe-errorpage/pull/11

Tested publishing an error page created that error page in `assets/`.

Test (after merging the framework pull request):

```
composer config repositories.cms vcs https://github.com/open-sausages/silverstripe-errorpage.git
composer require "silverstripe/errorpage:dev-pulls/4/vendorise-me-baby as 1.0.x-dev"
```