### PR TITLE
Update recipe branching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 
 # Install composer dependencies
   - export PATH=~/.composer/vendor/bin:$PATH
-  - composer require --no-update --prefer-dist silverstripe/recipe-cms:1.2.x-dev
+  - composer require --no-update --prefer-dist silverstripe/recipe-cms:4.2.x-dev
   - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - if [[ $DB == SQLITE ]]; then composer require --no-update silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.