### PR TITLE
MINOR Define default error code to avoid preview pane error in CMS

### DIFF
--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -42,7 +42,8 @@ class ErrorPage extends Page
 
     private static $defaults = array(
         "ShowInMenus" => 0,
-        "ShowInSearch" => 0
+        "ShowInSearch" => 0,
+        "ErrorCode" => 400
     );
 
     private static $table_name = 'ErrorPage';


### PR DESCRIPTION
Add a default error code when creating a new error page. This prevents an error being displayed in the preview pane when creating a draft for a brand new error page.

I set the default to 400. It sounded as sensible as any other code. Happy to change it to something else. 418 comes to mind.

# Parent issue
* https://github.com/silverstripe/silverstripe-cms/issues/1163