### PR TITLE
NEW: Add technical message to error page on dev environments

### DIFF
--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -57,6 +57,13 @@ class ErrorPage extends Page
     private static $icon_class = 'font-icon-p-error';
 
     /**
+     * Allow developers to opt out of dev messaging using Config
+     *
+     * @var boolean
+     */
+    private static $dev_append_error_message = true;
+
+    /**
      * Allows control over writing directly to the configured `GeneratedAssetStore`.
      *
      * @config
@@ -105,9 +112,12 @@ class ErrorPage extends Page
             Requirements::clear();
             Requirements::clear_combined_files();
 
+            //set @var dev_append_error_message to false to opt out of dev message
+            $showDevMessage = (self::config()->dev_append_error_message === true);
+
             if ($errorMessage) {
                 // Dev environments will have the error message added regardless of template changes
-                if (Director::isDev()) {
+                if (Director::isDev() && $showDevMessage === true) {
                     $errorPage->Content .= "\n<p><b>Error detail: "
                         . Convert::raw2xml($errorMessage) ."</b></p>";
                 }

--- a/src/ErrorPageControllerExtension.php
+++ b/src/ErrorPageControllerExtension.php
@@ -21,12 +21,12 @@ class ErrorPageControllerExtension extends Extension
      * @param HTTPRequest $request
      * @throws HTTPResponse_Exception
      */
-    public function onBeforeHTTPError($statusCode, $request)
+    public function onBeforeHTTPError($statusCode, $request, $errorMessage = null)
     {
         if (Director::is_ajax()) {
             return;
         }
-        $response = ErrorPage::response_for($statusCode);
+        $response = ErrorPage::response_for($statusCode, $errorMessage);
         if ($response) {
             throw new HTTPResponse_Exception($response, $statusCode);
         }


### PR DESCRIPTION
The formatting its pretty simple - just a bolded paragraph. It’s kept
off live environments to avoid inappropriate information leakage.

Fixes #30.