### PR TITLE
BUG Fix broken test when FulltextSearchable is enabled

### DIFF
--- a/tests/ErrorPageTest.php
+++ b/tests/ErrorPageTest.php
@@ -44,6 +44,11 @@ class ErrorPageTest extends FunctionalTest
         DB::quiet(true);
         TestAssetStore::reset();
         parent::tearDown();
+
+        // When this test is run after FulltextSearchable has been enabled, you end up with some gost DB entries
+        // that cause this test to fail.
+        $this->objFromFixture(ErrorPage::class, '404')->doUnpublish();
+        $this->objFromFixture(ErrorPage::class, '403')->doUnpublish();
     }
 
     public function test404ErrorPage()


### PR DESCRIPTION
So I'm not 100% sure why this is happening, but when FulltextSearchable is enabled the `testRequiredRecords` will throw an exception because the 404 error page is already published.

This happens only happens when the test is run after the cms test suite on the recipe-cms build because the `DatabaseSearchEngineTest` in CMS enables `FulltextSearchable`.

My solution is kind of dumb ... just manually unpublish the error pages after each test case. I'm pretty sure there has to be a less stupid way of fixing this, but it's not immediately apparent to me.