### PR TITLE
FIX: Fixed issue where a crash could occur when an error page is generated by the CMS

### DIFF
--- a/src/ErrorPageController.php
+++ b/src/ErrorPageController.php
@@ -11,10 +11,14 @@ use SilverStripe\View\SSViewer;
  */
 class ErrorPageController extends PageController
 {
+    /**
+     * Explicitly set themes to the themes config value in case the theme was previously set to something else
+     * One example of this is when serving 404 error pages under the admin path e.g. admin/non-existent
+     * where LeftAndMain::init() will have previously set themes to the admin_themes config
+     */
     protected function init()
     {
         SSViewer::set_themes(SSViewer::config()->themes);
-
         parent::init();
     }
 

--- a/src/ErrorPageController.php
+++ b/src/ErrorPageController.php
@@ -4,12 +4,20 @@ namespace SilverStripe\ErrorPage;
 use PageController;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\View\SSViewer;
 
 /**
  * Controller for ErrorPages.
  */
 class ErrorPageController extends PageController
 {
+    protected function init()
+    {
+        SSViewer::set_themes(SSViewer::config()->themes);
+
+        parent::init();
+    }
+
     /**
      * Overload the provided {@link Controller::handleRequest()} to append the
      * correct status code post request since otherwise permission related error


### PR DESCRIPTION
This pull request fixes an issue where an `InvalidArgumentException` will be thrown if the `PageController::init()` method defines requirements in the theme for the site and an error page is generated in the cms such as a page not found or server error. This is caused by `LeftAndMain` setting the theme mix to it's config setting `admin_themes`.

This affects all versions of Silverstripe that have been using the `admin_themes` config option to change SSViewer's themes. That said I've verified this issue is present in 4.7.3 and 4.6.1, I would assume it's also present in 4.8.

The one potential downside (though it may not be a bad thing) is that the theme's error page template is used as would be expected outside of the cms.