### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/cms": "^4@dev",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-errorpage/commit/5923f1f13e09a6051a8dfc67674522f4009e13d5

## Issue
- https://github.com/silverstripe/.github/issues/33