### PR TITLE
Remove `$` from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Provides an ErrorPage page type for the [Silverstripe CMS](https://github.com/si
 ## Installation
 
 ```
-$ composer require silverstripe/errorpage
+composer require silverstripe/errorpage
 ```
 
 You'll also need to run `dev/build`, which will generate a 500 and 404 error page.


### PR DESCRIPTION
Now that Github provides a copy/paste button, the `$` here is counter-productive.