### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -48,6 +48,14 @@ class ErrorPage extends Page
         "ErrorCode" => 400
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            // Scaffolded field is incorrect and poorly placed,
+            // so don't waste time scaffolding it
+            'ErrorCode',
+        ],
+    ];
+
     private static $table_name = 'ErrorPage';
 
     private static $allowed_children = [];


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767