### PR TITLE
Add extension hooks for static file writing

### DIFF
--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -322,6 +322,7 @@ class ErrorPage extends Page
         // Run the page (reset the theme, it might've been disabled by LeftAndMain::init())
         $originalThemes = SSViewer::get_themes();
         try {
+            $this->extend('onBeforeStaticWrite');
             // Restore front-end themes from config
             $themes = SSViewer::config()->get('themes') ?: $originalThemes;
             SSViewer::set_themes($themes);
@@ -336,6 +337,7 @@ class ErrorPage extends Page
         } finally {
             // Restore themes
             SSViewer::set_themes($originalThemes);
+            $this->extend('onAfterStaticWrite');
         }
 
         // Make sure we have content to save


### PR DESCRIPTION
Allowing for project level customisation of the environment within which the static content is obtained before it is written.

For example allowing third party modules to affect whether their middleware is active or not, which may otherwise prevent accurate content retrieval.