### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "silverstripe/cms": "^6",
-        "silverstripe/vendor-plugin": "^2"
+        "silverstripe/cms": "^6"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311